### PR TITLE
Add HTML content to email

### DIFF
--- a/src/Controllers/MailTesterController.php
+++ b/src/Controllers/MailTesterController.php
@@ -55,6 +55,7 @@ class MailTesterController extends Controller
 
             // Laravel >= 9.x Symfony Mailer
             $message->text($this->getBody());
+            $message->html($this->getBody());
         });
     }
 


### PR DESCRIPTION
Add HTML content to test email, to allow this to work with Mailcoach.

https://github.com/spatie/laravel-mailcoach-mailer

Thank you to Christophe for recommending this fix.